### PR TITLE
Adapt TuGraph statements to `v4.5.0`

### DIFF
--- a/tugraph/src/main/groovy/TugraphSwimmers.groovy
+++ b/tugraph/src/main/groovy/TugraphSwimmers.groovy
@@ -32,8 +32,8 @@ var run = { String s -> session.run(s) }
 
 '''
 CALL db.dropDB()
-CALL db.createVertexLabel('Swimmer', 'name', 'name', STRING, false, 'country', STRING, false)
-CALL db.createVertexLabel('Swim', 'id', 'id', INT32, false, 'event', STRING, false, 'result', STRING, false, 'at', STRING, false, 'time', FLOAT, false)
+CALL db.createVertexLabel('Swimmer', 'name', 'name', 'STRING', false, 'country', 'STRING', false)
+CALL db.createVertexLabel('Swim', 'id', 'id', 'INT32', false, 'event', 'STRING', false, 'result', 'STRING', false, 'at', 'STRING', false, 'time', 'FLOAT', false)
 CALL db.createEdgeLabel('swam','[["Swimmer","Swim"]]')
 CALL db.createEdgeLabel('supersedes','[["Swim","Swim"]]')
 '''.trim().readLines().each{ run(it) }


### PR DESCRIPTION
Since [TuGraph 4.5.0](https://github.com/TuGraph-family/tugraph-db/releases/tag/v4.5.0) has upgraded the query engine, when creating a schema, type keywords need to be enclosed in single quotes.

Old Usage:
`CALL db.createVertexLabel('Swimmer', 'name', 'name', STRING, false, 'country', STRING, false)`

New Usage:
`CALL db.createVertexLabel('Swimmer', 'name', 'name', 'STRING', false, 'country', 'STRING', false)`